### PR TITLE
fix: type-only import (TS1444)

### DIFF
--- a/src/components/VueEternalLoading/VueEternalLoading.vue
+++ b/src/components/VueEternalLoading/VueEternalLoading.vue
@@ -20,7 +20,8 @@
 </template>
 
 <script lang="ts" setup>
-import { nextTick, PropType, ref, watch, watchEffect } from 'vue';
+import { nextTick, ref, watch, watchEffect } from 'vue';
+import type { PropType } from 'vue';
 import {
   getScrollHeightFromEl,
   getScrollWidthFromEl,


### PR DESCRIPTION
Fixes:

```bash
node_modules/@ts-pro/vue-eternal-loading/src/components/VueEternalLoading/VueEternalLoading.vue:23:20 - error TS1444: 'PropType' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.

23 import { nextTick, PropType, ref, watch, watchEffect } from 'vue';
                      ~~~~~~~~
```

#5, #11