### PR TITLE
Export types in `exports` as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "import": "./dist/vue-eternal-loading.mjs",
     "default": "./dist/vue-eternal-loading.umd.js",
     "require": "./dist/vue-eternal-loading.js",
-    "node": "./dist/vue-eternal-loading.js"
+    "node": "./dist/vue-eternal-loading.js",
+    "types": "./src/main.ts"
   },
   "sideEffects": false,
   "author": "Oleksandr Havrashenko",


### PR DESCRIPTION
According to [Types that are found, but not exported in package.json, should still be usable](https://github.com/microsoft/TypeScript/issues/52363) we need to export types.

fix #18 , fix #16